### PR TITLE
Update to support Jekyll FrontMatter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,33 @@
 {
-	"name": "text-metadata-parser",
-	"version": "2.0.3",
-	"main": "./text-metadata-parser.js",
-	"author": {
-		"name": "TehShrike",
-		"email": "me@JoshDuff.com",
-		"url": "http://joshduff.com"
-	},
-	"description": "Text Metadata Parser was created for two reasons: to parse content and content metadata out of a single string or file, and to try to come up with the most boring library name ever!",
-	"keywords": [
-		"metadata",
-		"string",
-		"file"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/TehShrike/text-metadata-parser.git"
-	},
-	"devDependencies": {
-		"tap": "~0.4.4"
-	},
-	"dependencies": {
-		"weak-type-wizard": "^1.0.0"
-	},
-	"directories": {
-		"test": "test"
-	},
-	"scripts": {
-		"test": "tap ./test/*.js"
-	}
+  "name": "text-metadata-parser",
+  "version": "2.0.3",
+  "main": "./text-metadata-parser.js",
+  "author": {
+    "name": "TehShrike",
+    "email": "me@JoshDuff.com",
+    "url": "http://joshduff.com"
+  },
+  "description": "Text Metadata Parser was created for two reasons: to parse content and content metadata out of a single string or file, and to try to come up with the most boring library name ever!",
+  "keywords": [
+    "metadata",
+    "string",
+    "file"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TehShrike/text-metadata-parser.git"
+  },
+  "devDependencies": {
+    "tap": "~0.4.4"
+  },
+  "dependencies": {
+    "weak-type-wizard": "^1.0.0",
+    "yaml-front-matter": "^3.2.3"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "tap ./test/*.js"
+  }
 }

--- a/test/testDefaults.js
+++ b/test/testDefaults.js
@@ -1,29 +1,25 @@
 var test = require('tap').test
 var parse = require('../')
 
-test("defaults", function(t) {
-	var str = "what is it: 13\n\n"
-		+ "Who knows!"
+test('setting default values', function(t) {
+	var str =
+		  'what is it: 13\n'
+		+ '\n'
+		+ 'Who knows!'
 
 	var result = parse(str, {
 		default: {
-			"what is it": 10,
-			"or this one": 20
+			'what is it': 10,
+			'or this one': 20,
+			'one more': 123
 		},
-		string: "or this one"
+		string: 'or this one'
 	})
 
-	test("using the provided value instead of the default", function(t) {
-		t.equal(result.metadata['what is it'], "13")
-		t.end()
-	})
-
-	test("using the default because no value was provided", function(t) {
-		t.equal(result.metadata['or this one'], "20")
-		t.end()
-	})
-	
-	t.equal(result.content, "Who knows!", "matching body")
+	t.equal(result.metadata['what is it'], 13, 'use the provided value instead of the default')
+	t.equal(result.metadata['or this one'], '20', 'use the default because no value was provided')	
+	t.equal(typeof result.metadata['one more'], 'number', 'should be a number')
+	t.equal(result.content, 'Who knows!', 'content matches')
 
 	t.end()
 })

--- a/test/testJekyllFrontMatters.js
+++ b/test/testJekyllFrontMatters.js
@@ -1,0 +1,228 @@
+var test = require('tap').test
+var parse = require('../')
+
+test("first generic test", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title:    Last will and testament\n"
+		+ "date:     2019-09-13\n"
+		+ "attn:     Secret Family\n"
+		+ "lovers:   3\n"
+		+ "deceased: true\n"
+		+ "---\n"
+		+ "\n"
+		+ "I leave everything to Janet.\n"
+		+ "\n"
+		+ "Except my boots.  Those are *mine.*"
+
+	var parsed_string = parse(markdown_string, {
+		number: ['lovers', 'bagels'],
+		string: ['title', 'attn'],
+		date: ['date'],
+		boolean: 'deceased',
+		default: { lovers: 5, bagels: 3.5 }
+	})
+
+	t.equal(parsed_string.metadata.title, 'Last will and testament', 'parse title')
+	t.similar(parsed_string.metadata.date, new Date('2019-09-13'), 'test date') // new Date(string) is local timezone, new Date(y,m,d) is UTC...
+	t.equal(parsed_string.metadata.attn, 'Secret Family', 'attn field')
+	t.equal(parsed_string.metadata.lovers, 3, 'number of lovers')
+	t.equal(parsed_string.metadata.bagels, 3.5, 'default bagels')
+	t.equal(parsed_string.metadata.deceased, true, 'boolean value')
+	t.equal(parsed_string.content,
+		  "I leave everything to Janet.\n"
+		+ "\n"
+		+ "Except my boots.  Those are *mine.*")
+
+	t.end()
+})
+
+test("colon in content, newlines at content end", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title:    my sweet title\n"
+		+ "---\n"
+		+ "\n\n"
+		+ "not_a_value: unreal\n\n"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'parse title')
+	t.equal(parsed_string.content, "not_a_value: unreal\n\n", 'newlines preserved')
+
+	t.end()
+})
+
+test("newline versus carriage return", function test(t) {
+
+	var markdown_string =
+		  "---\r\n"
+		+ "title:    my sweet title\r\n"
+		+ "---\r\n"
+		+ "\r\n"
+		+ "not_a_value: unreal\r\n"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'title does not contain newline or carriage return')
+	t.equal(parsed_string.content, "not_a_value: unreal\r\n", 'newline and carriage return preserved')
+
+	t.end()
+})
+
+test("text is parsed if no empty newline after dashes", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title:    my sweet title\n"
+		+ "---\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'title still parses')
+	t.equal(parsed_string.content, 'this is some text', 'text is parsed')
+
+	t.end()
+})
+
+test("whitespace before metadata key", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "    title:    my sweet title\n"
+		+ "---\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'metadata still parses')
+
+	t.end()
+})
+
+test("whitespace after metadata key", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title    :    my sweet title\n"
+		+ "---\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'metadata still parses')
+
+	t.end()
+})
+
+test("whitespace between metadata keys", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title    :    my sweet title\n"
+		+ "---\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string, {
+		string: ['title']
+	})
+
+	t.equal(parsed_string.metadata.title, 'my sweet title', 'metadata still parses')
+
+	t.end()
+})
+
+test("multi level metadata values for frontmatter are supported", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "things:\n"
+		+ "  - thing one\n"
+		+ "  - thing two\n"
+		+ "---\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string)
+
+	t.equal(parsed_string.metadata.things[0], 'thing one', 'metadata arrays parse')
+	t.equal(parsed_string.metadata.things[1], 'thing two', 'metadata arrays parse')
+
+	t.end()
+})
+
+test("a number as a frontmatter value should be cast to a number", function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "thing: 7\n"
+		+ "---\n"
+		+ "\n"
+		+ "my sweet content\n\n"
+
+	var parsed_string = parse(markdown_string)
+
+	t.equal(typeof parsed_string.metadata.thing, 'number', 'cast to a number')
+
+	t.end()
+})
+
+test('the weak-type-wizard casts simple things to simple types', function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "thing: 7\n"
+		+ "---\n"
+		+ "\n"
+		+ "my sweet content\n\n"
+
+	var parsed_string = parse(markdown_string, {
+		string: [ 'thing' ]
+	})
+
+	t.equal(typeof parsed_string.metadata.thing, 'string', 'cast to a number')
+
+	t.end()
+})
+
+test('if no dashes around metadata it quotes value when containing semicolon', function test(t) {
+
+	var markdown_string =
+		  "title: Day One: Pants.\n"
+		+ "\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string)
+
+	t.equal(parsed_string.metadata.title, 'Day One: Pants.', 'metadata still parses')
+
+	t.end()
+})
+
+test('we do not fudge around with yaml though, you have to quote it yourself', function test(t) {
+
+	var markdown_string =
+		  "---\n"
+		+ "title: Day One: Pants.\n"
+		+ "---\n"
+		+ "\n"
+		+ "this is some text"
+
+	t.throws(function() {
+		parse(markdown_string)
+	})
+
+	t.end()
+})

--- a/test/testJekyllFrontMatters.js
+++ b/test/testJekyllFrontMatters.js
@@ -52,7 +52,7 @@ test("colon in content, newlines at content end", function test(t) {
 	})
 
 	t.equal(parsed_string.metadata.title, 'my sweet title', 'parse title')
-	t.equal(parsed_string.content, "not_a_value: unreal\n\n", 'newlines preserved')
+	t.equal(parsed_string.content, "not_a_value: unreal", 'newlines preserved')
 
 	t.end()
 })
@@ -71,7 +71,7 @@ test("newline versus carriage return", function test(t) {
 	})
 
 	t.equal(parsed_string.metadata.title, 'my sweet title', 'title does not contain newline or carriage return')
-	t.equal(parsed_string.content, "not_a_value: unreal\r\n", 'newline and carriage return preserved')
+	t.equal(parsed_string.content, "not_a_value: unreal", 'newline and carriage return preserved')
 
 	t.end()
 })

--- a/test/testThings.js
+++ b/test/testThings.js
@@ -48,7 +48,7 @@ test("colon in content, newlines at content end", function test(t) {
 	})
 
 	t.equal(parsed_string.metadata.title, 'my sweet title', 'parse title')
-	t.equal(parsed_string.content, "not_a_value: unreal\n\n", 'newlines preserved')
+	t.equal(parsed_string.content, "not_a_value: unreal", 'newlines preserved')
 
 	t.end()
 })
@@ -65,7 +65,7 @@ test("newline versus carriage return", function test(t) {
 	})
 
 	t.equal(parsed_string.metadata.title, 'my sweet title', 'title does not contain newline or carriage return')
-	t.equal(parsed_string.content, "not_a_value: unreal\r\n", 'newline and carriage return preserved')
+	t.equal(parsed_string.content, "not_a_value: unreal", 'newline and carriage return preserved')
 
 	t.end()
 })
@@ -101,7 +101,6 @@ test("whitespace before metadata key", function test(t) {
 	t.end()
 })
 
-
 test("whitespace after metadata key", function test(t) {
 
 	var markdown_string =
@@ -113,6 +112,41 @@ test("whitespace after metadata key", function test(t) {
 	})
 
 	t.equal(parsed_string.metadata.title, 'my sweet title', 'metadata still parses')
+
+	t.end()
+})
+
+test("unbounded yaml what does it do? it breaks things! surround with the three dashes", function test(t) {
+
+	var markdown_string =
+		  "title: sweetness\n"
+		+ "more:\n"
+		+ "  - thing\n"
+		+ "  - other\n"
+		+ "\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string)
+
+	t.equal(parsed_string.metadata.title, 'sweetness', 'first simple metadata still parses')
+	t.equal(parsed_string.metadata.more, undefined, 'the simple key:value of old does not support anything complex')
+	t.equal(parsed_string.content, '- thing\n  - other\n\nthis is some text', 'the first line without : is the content')
+
+	t.end()
+})
+
+test('another example of unbounded yaml with no values', function test(t) {
+
+	var markdown_string =
+		  "title: sweetness\n"
+		+ "more:\n"
+		+ "this is some text"
+
+	var parsed_string = parse(markdown_string)
+
+	t.equal(parsed_string.metadata.title, 'sweetness', 'metadata still parses')
+	t.equal(parsed_string.metadata.more, undefined, 'metadata still parses')
+	t.equal(parsed_string.content, 'this is some text')
 
 	t.end()
 })

--- a/text-metadata-parser.js
+++ b/text-metadata-parser.js
@@ -1,20 +1,24 @@
 var Wizard = require('weak-type-wizard')
+var yaml = require('yaml-front-matter')
 
-function parseString(text) {
-	var lines = text.split("\n")
+function formatKeyValue(key, value) {
+	return key + ': ' + (value.indexOf(':') >= 0 ? '"' + value + '"' : value)
+}
+
+function makeBackwardsCompatible(text) {
+	var lines = text.split('\n')
 	var done_reading_metadata = false
 	var done_reading_whitespace = false
-	var parsed_object = { content: "", metadata: {} }
+	var metadataLines = []
 
 	for (var i = 0; i < lines.length && !done_reading_whitespace; i++) {
 		if (!done_reading_metadata) {
 			var found_metadata = /^([^:]+):\s*([^\r\n]+)\s*$/.exec(lines[i])
 			if (found_metadata && found_metadata.length === 3) {
-				var property = found_metadata[1].trim()
-				parsed_object.metadata[property] = found_metadata[2]
-			} else if (i === 0) {
-				return { content: text, metadata: {} }
-			} else {
+				var key = found_metadata[1].trim()
+				var value = found_metadata[2].trim()
+				metadataLines.push(formatKeyValue(key, value))
+			} else if (i >= 0) {
 				done_reading_metadata = true
 			}
 		} else if (!done_reading_whitespace) {
@@ -22,11 +26,26 @@ function parseString(text) {
 		}
 	}
 
-	parsed_object.content = lines.slice(i - 1).join("\n")
+	var metadata = '---\n' + metadataLines.join('\n') + '\n---\n'
+	var content = metadata + lines.slice(i - 1).join('\n')
 
-	return parsed_object
+	return content
 }
 
+function parseString(text) {
+	if (text.indexOf('---') !== 0) {
+		text = makeBackwardsCompatible(text)
+	}
+	var parsedYaml = yaml.loadFront(text)
+
+	var output = {
+		content: parsedYaml.__content.trim()
+	}
+	delete parsedYaml.__content
+	output.metadata = parsedYaml
+
+	return output
+}
 
 function parse(wizard, text) {
 	var post = parseString(text)


### PR DESCRIPTION
The following changes were made:

* Supports Jekyll's [FrontMatters](http://jekyllrb.com/docs/frontmatter/) syntax. Maybe people who use Jekyll can migrate easier!
* Backwards compatibility with the old metadata syntax is almost exactly supported, the primary difference is that the content is trimmed.

:heart: 