### PR TITLE
Update to latest js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "js-yaml": "^3.3.0",
+    "js-yaml": "^3.5.2",
     "weak-type-wizard": "^1.0.0"
   },
   "directories": {


### PR DESCRIPTION
This should drop esprima.

See https://github.com/TehShrike/noddity/issues/27
